### PR TITLE
Fix config-defined view_formats not being array

### DIFF
--- a/ckanext/geoview/plugin.py
+++ b/ckanext/geoview/plugin.py
@@ -131,7 +131,7 @@ class OLGeoView(GeoViewBase):
 
         view_formats = config.get('ckanext.geoview.ol_viewer.formats', '')
         if view_formats:
-            view_formats.split(' ')
+            view_formats = view_formats.split(' ')
         else:
             view_formats = GEOVIEW_FORMATS
 


### PR DESCRIPTION
string.split() returns an array. We have to re-assign the view_formats variable to then have that array, and have the code behave as expected.

This was manifesting as a bug for me as I wanted to remove disable the map for `geojson` (a separate plugin is rendering this for me), but the `correct_format` variable was True - despite `geojson` not being defined in my config.  The problem was `view_formats` being a string containing `kml gml wms wfs esrigeojson gft arcgis_rest`, so `format_lower in view_formats` evaluates to `True` because `geojson` is in the middle of the string (being the suffix on `esrigeojson`).
